### PR TITLE
Add 1.20.5+ Support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,7 +57,7 @@ abstract class FileOutput : DefaultTask() {
     abstract val output: Property<File>
 }
 
-val bootstrapVersion = "0.2.0"
+val bootstrapVersion = "0.5.2"
 val bootstrapArch = "i686"
 
 val downloadBootstrap by tasks.registering(Download::class) {

--- a/src/main/kotlin/io/github/gaming32/additiveinstaller/PackInstaller.kt
+++ b/src/main/kotlin/io/github/gaming32/additiveinstaller/PackInstaller.kt
@@ -132,20 +132,6 @@ class PackInstaller(
                 .asJsonArray
                 .add("-D$prefix=$modsDir$suffix")
         }
-        if ((packVersion.packVersion.toVersion() >= "1.15.9".toVersion()) && (packVersion.packVersion.toVersion() <= "1.20.4".toVersion())) {
-            // HACK HACK HACK World Host has a bug where Java 17 is required
-            clientJson["javaVersion"] = JsonObject().apply {
-                this["component"] = "java-runtime-gamma"
-                this["majorVersion"] = 17
-            }
-        }
-        if (packVersion.packVersion.toVersion() >= "1.20.5".toVersion()) {
-            // 1.20.5 + Require Java 21
-            clientJson["javaVersion"] = JsonObject().apply {
-                this["component"] = "java-runtime-delta"
-                this["majorVersion"] = 21
-            }
-        }
 
         writeVersionDir(clientJson)
         updateLauncherProfiles()

--- a/src/main/kotlin/io/github/gaming32/additiveinstaller/PackInstaller.kt
+++ b/src/main/kotlin/io/github/gaming32/additiveinstaller/PackInstaller.kt
@@ -132,11 +132,18 @@ class PackInstaller(
                 .asJsonArray
                 .add("-D$prefix=$modsDir$suffix")
         }
-        if (packVersion.packVersion.toVersion() >= "1.15.9".toVersion()) {
+        if ((packVersion.packVersion.toVersion() >= "1.15.9".toVersion()) && (packVersion.packVersion.toVersion() <= "1.20.4".toVersion())) {
             // HACK HACK HACK World Host has a bug where Java 17 is required
             clientJson["javaVersion"] = JsonObject().apply {
                 this["component"] = "java-runtime-gamma"
                 this["majorVersion"] = 17
+            }
+        }
+        if (packVersion.packVersion.toVersion() >= "1.20.5".toVersion()) {
+            // 1.20.5 + Require Java 21
+            clientJson["javaVersion"] = JsonObject().apply {
+                this["component"] = "java-runtime-delta"
+                this["majorVersion"] = 21
             }
         }
 


### PR DESCRIPTION
Upgraded Fabric Bootstrap version to handle 1.20.5+ / Java 21
Added detection for 1.20.5+

Tested on my other fork:
https://github.com/TeamTEDS/teds-plus-installer